### PR TITLE
Mark test requiring ollama server as xfail

### DIFF
--- a/src/geo_assistant/agent/graph.py
+++ b/src/geo_assistant/agent/graph.py
@@ -5,7 +5,7 @@ from langchain.agents import create_agent
 from geo_assistant.agent.state import GeoAssistantState
 from geo_assistant.agent.llms import llm
 from geo_assistant.tools.overture import get_place
-from src.geo_assistant.tools.buffer import get_search_area
+from geo_assistant.tools.buffer import get_search_area
 
 SYSTEM_PROMPT = """
 You are a helpful assistant that can answer questions and help with tasks.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,7 @@ async def initialized_app():
         del app.state.chatbot
 
 
-@pytest.mark.asyncio
+@pytest.mark.xfail
 async def test_hello_world(initialized_app):
     """Hello world test for the API"""
     async with AsyncClient(

--- a/tests/tools/test_summarize.py
+++ b/tests/tools/test_summarize.py
@@ -16,6 +16,7 @@ TEST_IMAGE_URL = "https://petapixel.com/assets/uploads/2022/08/French-Officials-
         (TEST_IMAGE_URL, "building"),
     ],
 )
+@pytest.mark.xfail
 def test_summarize_sat_img(img_url, summary):
     command = summarize_sat_img.invoke(
         ToolCall(


### PR DESCRIPTION
Should only run these slow tests requiring an `ollama` server locally for now

Output from CI at https://github.com/developmentseed/geo-assistant/actions/runs/19934109297/job/57154006995?pr=10#step:6:14

```
Run uv run pytest --verbose
  
============================= test session starts ==============================
platform linux -- Python 3.13.9, pytest-9.0.1, pluggy-1.6.0 -- /home/runner/work/geo-assistant/geo-assistant/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/runner/work/geo-assistant/geo-assistant
configfile: pyproject.toml
plugins: anyio-4.12.0, asyncio-1.3.0, langsmith-0.4.53
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 4 items
tests/test_api.py::test_hello_world XFAIL                                [ 25%]
tests/tools/test_buffer.py::test_get_search_area PASSED                  [ 50%]
tests/tools/test_overture.py::test_get_place PASSED                      [ 75%]
tests/tools/test_summarize.py::test_summarize_sat_img[https://petapixel.com/assets/uploads/2022/08/French-Officials-Use-Satellite-Photos-and-AI-to-Spot-Unregistered-Pools-1536x806.jpg-building] XFAIL [100%]
```